### PR TITLE
FROM `node:lts-alpine3.12`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM node:lts-alpine3.12
 
 LABEL AUTHOR="none" \
       VERSION=0.1.4
@@ -14,8 +14,7 @@ ENV DEFAULT_LIST_FILE=crontab_list.sh \
 RUN set -ex \
     && apk update \
     && apk upgrade \
-    && apk add bash \
-    && apk add --no-cache tzdata git nodejs moreutils npm curl jq openssh-client \
+    && apk add --no-cache bash tzdata git moreutils curl jq openssh-client \
     && rm -rf /var/cache/apk/* \
     && ln -sf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime \
     && echo "Asia/Shanghai" > /etc/timezone \


### PR DESCRIPTION
Node版本与官方`LTS`版本保持一致，并兼容armv7架构。解决Issue https://github.com/wisz2021/jd_docker/issues/5#issuecomment-842113061